### PR TITLE
feat: add github no reply email detection

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,10 +1,22 @@
 export const CONFIRMATION_MESSAGE = 'All good 🎉 feels good to give back!'
-export const CONFIRMATION_COMMENT = `Thank you for your contribution to WebdriverIO! Your pull request has been marked as an "Expensable" contribution. We've sent you an email with further instructions on how to claim your expenses from our development fund. Please make sure to check your spam folder as well. If you have any questions, feel free to reach out to us at __expense@webdriver.io__ or in the contributing channel on [Discord](https://discord.webdriver.io).
 
-We are looking forward to more contributions from you in the future 🙌
+const COMMENT_HEADER = `Thank you for your contribution to WebdriverIO! Your pull request has been marked as an "Expensable" contribution.
+
+We've sent you an email with further instructions on how to claim your expenses from our development fund.\n`
+
+const EMAIL_WARNING = `Please make sure to check your spam folder as well. If you have any questions, feel free to reach out to us at __expense@webdriver.io__ or in the contributing channel on [Discord](https://discord.webdriver.io).\n\n`
+const EMAIL_WARNING_GHNOREPLY = `⚠️ You seemed to have committed using an email address ending up with \`@users.noreply.github.com\`, if you don't receive the email please feel free to reach out to us at __expense@webdriver.io__ or in the contributing channel on [Discord](https://discord.webdriver.io).\n\n`
+
+const COMMENT_FOOTER = `We are looking forward to more contributions from you in the future 🙌
 
 Have a nice day,
 The WebdriverIO Team 🤖`
+
+export const CONFIRMATION_COMMENT =
+    COMMENT_HEADER + EMAIL_WARNING + COMMENT_FOOTER
+
+export const CONFIRMATION_COMMENT_GHNOREPLY =
+    COMMENT_HEADER + EMAIL_WARNING_GHNOREPLY + COMMENT_FOOTER
 
 export const FROM = 'WebdriverIO Team <sponsor@webdriver.io>'
 export const BCC = 'expense@webdriver.io'

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -167,7 +167,7 @@ describe('expense', () => {
         vi.mocked(get).mockResolvedValue(pulls)
         await expect(async () =>
             expense({
-                githubToken: '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',
+                githubToken: 'token',
                 resendAPIKey: 'token',
                 actionRepo: 'webdriverio/webdriverio'
             })
@@ -181,7 +181,7 @@ describe('expense', () => {
         vi.mocked(get).mockResolvedValue(pulls)
         await expect(async () =>
             expense({
-                githubToken: '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',
+                githubToken: 'token',
                 resendAPIKey: 'token',
                 actionRepo: 'webdriverio/webdriverio'
             })


### PR DESCRIPTION
Solves #86 

This PR contains 2 commits:
- A small removal of the hardcoded Github token, while they are already invalid credentials, it may attract unwanted attention from token crawlers
- The feature itself:
  - Added a bit of breathing space to the original Github comment (thus updating the snapshot)
  - Logic, new comment, and tests for the new detection feature 
- Build of the `dist` folder (includes changes from #87 ) 
  
I'm not very familiar with Vitest mocking, but I had to add a `createComment.mockClear()`, let me know if I should avoid it.